### PR TITLE
feat: add reply_settings to tweetFields and pinnedTweet property to User

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -20,7 +20,7 @@ export const userFields =
   'created_at,description,entities,id,location,name,pinned_tweet_id,profile_image_url,protected,public_metrics,url,username,verified,withheld';
 
 export const tweetFields =
-  'attachments,author_id,context_annotations,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,source,text,withheld';
+  'attachments,author_id,context_annotations,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,reply_settings,source,text,withheld';
 
 export const mediaFields =
   'duration_ms,height,media_key,preview_image_url,type,url,width,public_metrics,non_public_metrics,organic_metrics,promoted_metrics';

--- a/src/util/StructureBuilder.js
+++ b/src/util/StructureBuilder.js
@@ -2,6 +2,7 @@
 
 import User from '../structures/User.js';
 import Collection from './Collection.js';
+import Tweet from '../structures/Tweet.js';
 
 /**
  * Builds a User structure
@@ -13,11 +14,13 @@ export function userBuilder(client, userData) {
     const usersCollection = new Collection();
     userData.forEach(element => {
       const user = new User(client, element.data);
+      user.pinnedTweet = new Tweet(client, element.includes.tweets[0]);
       usersCollection.set(user.id, user);
     });
     return usersCollection;
   } else {
     const user = new User(client, userData.data);
+    user.pinnedTweet = new Tweet(client, userData.includes.tweets[0]);
     return user;
   }
 }


### PR DESCRIPTION
Twitter recently released a new tweet field named `reply_settings` which states who can reply to a given tweet. This PR adds that field to `tweetFields` while also adding the `pinnedTweet` property of a `User` object.