### PR TITLE
feat: add a new Entity structure and a few bug fixes

### DIFF
--- a/src/structures/Entity.js
+++ b/src/structures/Entity.js
@@ -1,0 +1,104 @@
+'use strict';
+
+import Url from './Url.js';
+import Mention from './Mention.js';
+import Hashtag from './Hashtag.js';
+import Cashtag from './Cashtag.js';
+
+/**
+ * Holds all entities present in a user's profile
+ */
+class Entity {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    /**
+     * The URL present in a user's bio
+     * @type {?Url}
+     */
+    this.url = data?.url?.urls[0] ? new Url(data.url.urls[0]) : null;
+
+    /**
+     * The mentions present in the description of a user's bio
+     * @type {?Mention}
+     */
+    this.mentions = data?.description?.mentions ? this._patchMentions(data.description.mentions) : null;
+
+    /**
+     * The hashtags present in the description of a user's bio
+     * @type {?Hastag}
+     */
+    this.hashtags = data?.description?.hashtags ? this._patchHashtags(data.description.hashtags) : null;
+
+    /**
+     * The cashtags present in the description of a user's bio
+     * @type {?Cashtag}
+     */
+    this.cashtags = data?.description?.cashtags ? this._patchCashtags(data.description.cashtags) : null;
+
+    /**
+     * The URLs present in the description of a user's bio
+     * @type {?Url}
+     */
+    this.descriptionUrls = data?.description?.urls ? this._patchDescriptionUrls(data.description.urls) : null;
+  }
+
+  /**
+   * Adds data to the mentions property of Entity
+   * @param {Array<Object>} mentions An array of raw mentions
+   * @private
+   * @returns {Array<Mention>}
+   */
+  _patchMentions(mentions) {
+    const mentionsArray = [];
+    mentions.forEach(mention => {
+      mentionsArray.push(new Mention(mention));
+    });
+    return mentionsArray;
+  }
+
+  /**
+   * Adds data to the hashtags property of Entity
+   * @param {Array<Object>} hashtags An array of raw hastags
+   * @private
+   * @returns {Array<Hashtag>}
+   */
+  _patchHashtags(hashtags) {
+    const hashtagsArray = [];
+    hashtags.forEach(hashtag => {
+      hashtagsArray.push(new Hashtag(hashtag));
+    });
+    return hashtagsArray;
+  }
+
+  /**
+   * Adds data to the cashtags property of Entity
+   * @param {Array<Object>} cashtags An array of raw cashtags
+   * @private
+   * @returns {Array<Cashtag>}
+   */
+  _patchCashtags(cashtags) {
+    const cashtagsArray = [];
+    cashtags.forEach(cashtag => {
+      cashtagsArray.push(new Cashtag(cashtag));
+    });
+    return cashtagsArray;
+  }
+
+  /**
+   * Adds data to the descriptionUrls property of Entity
+   * @param {Array<Object>} descriptionUrls An array of raw descriptionUrls
+   * @private
+   * @returns {Array<Url>}
+   */
+  _patchDescriptionUrls(descriptionUrls) {
+    const descriptionUrlsArray = [];
+    descriptionUrls.forEach(descriptionUrl => {
+      descriptionUrlsArray.push(new Url(descriptionUrl));
+    });
+    return descriptionUrlsArray;
+  }
+}
+
+export default Entity;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -33,7 +33,7 @@ class User extends BaseStructure {
 
     /**
      * Entities in the description of the user
-     * @type {?object}
+     * @type {?Entity}
      */
     this.entities = null;
 

--- a/src/util/ResponseCleaner.js
+++ b/src/util/ResponseCleaner.js
@@ -11,7 +11,7 @@ export function cleanFetchManyUsersResponse(response) {
       userData.data = data;
       userDataCollection.set(data.id, userData);
     });
-    element.includes.tweets.forEach(tweet => {
+    element?.includes?.tweets.forEach(tweet => {
       const userData = userDataCollection.get(tweet.author_id);
       userData.includes.tweets.push(tweet);
       userDataCollection.set(tweet.author_id, userData);

--- a/src/util/StructureBuilder.js
+++ b/src/util/StructureBuilder.js
@@ -4,6 +4,7 @@ import User from '../structures/User.js';
 import Collection from './Collection.js';
 import Tweet from '../structures/Tweet.js';
 import UserPublicMetrics from '../structures/UserPublicMetrics.js';
+import Entity from '../structures/Entity.js';
 
 /**
  * Builds a User structure
@@ -15,10 +16,11 @@ export function userBuilder(client, userData) {
     const usersCollection = new Collection();
     userData.forEach(element => {
       const user = new User(client, element.data);
-      if (element.includes?.tweets) {
+      if (element.includes?.tweets[0]) {
         user.pinnedTweet = new Tweet(client, element.includes.tweets[0]);
       }
       user.publicMetrics = new UserPublicMetrics(element.data.public_metrics);
+      user.entities = new Entity(element.data.entities);
       usersCollection.set(user.id, user);
     });
     return usersCollection;
@@ -28,6 +30,7 @@ export function userBuilder(client, userData) {
       user.pinnedTweet = new Tweet(client, userData.includes.tweets[0]);
     }
     user.publicMetrics = new UserPublicMetrics(userData.data.public_metrics);
+    user.entities = new Entity(userData.data.entities);
     return user;
   }
 }


### PR DESCRIPTION
This PR adds a new `Entity` structure. This structure can be accessed from the `entities` property of a `User` object. The PR also fixes some bugs like error related to `pinnedTweet` when fetching a `User` that has no pinned tweet. 