### PR TITLE
feat(Attachment): add new structure for attachments in a tweet

### DIFF
--- a/src/structures/Attachment.js
+++ b/src/structures/Attachment.js
@@ -1,0 +1,41 @@
+'use strict';
+
+import Media from './Media.js';
+import Poll from './Poll.js';
+
+/**
+ * Holds attachments like media and poll in a tweet
+ */
+class Attachment {
+  constructor(data) {
+    /**
+     * The poll present in the tweet
+     * @type {Poll}
+     */
+    this.polls = data?.polls ? this._patchPoll(data.polls) : null;
+
+    /**
+     * The media present in the tweet
+     * @type {Media}
+     */
+    this.media = data?.media ? this._patchMedia(data.media) : null;
+  }
+
+  _patchPoll(polls) {
+    const pollsArray = [];
+    polls.forEach(poll => {
+      pollsArray.push(new Poll(poll));
+    });
+    return pollsArray;
+  }
+
+  _patchMedia(media) {
+    const mediaArray = [];
+    media.forEach(media => {
+      mediaArray.push(new Media(media));
+    });
+    return mediaArray;
+  }
+}
+
+export default Attachment;

--- a/src/util/StructureBuilder.js
+++ b/src/util/StructureBuilder.js
@@ -5,6 +5,7 @@ import Collection from './Collection.js';
 import Tweet from '../structures/Tweet.js';
 import UserPublicMetrics from '../structures/UserPublicMetrics.js';
 import Entity from '../structures/Entity.js';
+import Attachment from '../structures/Attachment.js';
 
 /**
  * Builds a User structure
@@ -59,5 +60,7 @@ function _patchTweet(client, element) {
   if (authorPublicMetricsData) tweet.author.publicMetrics = new UserPublicMetrics(authorPublicMetricsData);
   const authorEntityData = authorData?.entities;
   if (authorEntityData) tweet.author.entities = new Entity(authorEntityData);
+  const attachmentsData = element?.includes;
+  if (attachmentsData) tweet.attachments = new Attachment(attachmentsData);
   return tweet;
 }


### PR DESCRIPTION
This PR adds a new structure that holds all the attachments like media and polls present in a tweet.