### PR TITLE
feat: add strucutre and property for tweet public metrics

### DIFF
--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import BaseStructure from './BaseStructure.js';
+import TweetPublicMetrics from './TweetPublicMetrics.js';
 
 /**
  * A tweet on Twitter
@@ -96,7 +97,7 @@ class Tweet extends BaseStructure {
     /**
      * The public metrics of the tweet
      */
-    this.publicMetrics = null;
+    this.publicMetrics = data?.public_metrics ? this._patchPublicMetrics(data.public_metrics) : null;
 
     /**
      * Tweets this tweet refers to
@@ -119,6 +120,10 @@ class Tweet extends BaseStructure {
      * The withholding details for the tweet if it is withheld
      */
     this.withheld = null;
+  }
+
+  _patchPublicMetrics(publicMetrics) {
+    return new TweetPublicMetrics(publicMetrics);
   }
 }
 

--- a/src/structures/TweetPublicMetrics.js
+++ b/src/structures/TweetPublicMetrics.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Represents public metrics in a tweet
+ */
+class TweetPublicMetrics {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    /**
+     * The number of times the tweet got retweeted
+     * @type {number}
+     */
+    this.retweetCount = data.retweet_count;
+
+    /**
+     * The number of replies the tweet has
+     * @type {number}
+     */
+    this.replyCount = data.reply_count;
+
+    /**
+     * The number of likes the tweet has
+     * @type {number}
+     */
+    this.likeCount = data.like_count;
+
+    /**
+     * The number of times the tweet got retweeted with a comment
+     * @type {number}
+     */
+    this.quoteCount = data.quote_count;
+  }
+}
+
+export default TweetPublicMetrics;


### PR DESCRIPTION
This PR adds a new `TweetPublicMetrics` structure that represents public metrics of a tweet eg. `like`, `retweet` etc. It also implements the `publicMetrics` property of `Tweet`.