### PR TITLE
feat: add base class for entity classes

### DIFF
--- a/src/structures/BaseEntity.js
+++ b/src/structures/BaseEntity.js
@@ -1,0 +1,77 @@
+'use strict';
+
+import Mention from './Mention.js';
+import Hashtag from './Hashtag.js';
+import Cashtag from './Cashtag.js';
+
+/**
+ * Base class for tweet and use entity classes
+ */
+class Entity {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    /**
+     * The mentions present in the text
+     * @type {?Mention}
+     */
+    this.mentions = data?.mentions ? this._patchMentions(data.mentions) : null;
+
+    /**
+     * The hashtags present in the text
+     * @type {?Hastag}
+     */
+    this.hashtags = data?.hashtags ? this._patchHashtags(data.hashtags) : null;
+
+    /**
+     * The cashtags present in the text
+     * @type {?Cashtag}
+     */
+    this.cashtags = data?.cashtags ? this._patchCashtags(data.cashtags) : null;
+  }
+
+  /**
+   * Adds data to the mentions property
+   * @param {Array<Object>} mentions An array of raw mentions
+   * @private
+   * @returns {Array<Mention>}
+   */
+  _patchMentions(mentions) {
+    const mentionsArray = [];
+    mentions.forEach(mention => {
+      mentionsArray.push(new Mention(mention));
+    });
+    return mentionsArray;
+  }
+
+  /**
+   * Adds data to the hashtags property
+   * @param {Array<Object>} hashtags An array of raw hastags
+   * @private
+   * @returns {Array<Hashtag>}
+   */
+  _patchHashtags(hashtags) {
+    const hashtagsArray = [];
+    hashtags.forEach(hashtag => {
+      hashtagsArray.push(new Hashtag(hashtag));
+    });
+    return hashtagsArray;
+  }
+
+  /**
+   * Adds data to the cashtags property
+   * @param {Array<Object>} cashtags An array of raw cashtags
+   * @private
+   * @returns {Array<Cashtag>}
+   */
+  _patchCashtags(cashtags) {
+    const cashtagsArray = [];
+    cashtags.forEach(cashtag => {
+      cashtagsArray.push(new Cashtag(cashtag));
+    });
+    return cashtagsArray;
+  }
+}
+
+export default Entity;

--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import BaseStructure from './BaseStructure.js';
+import TweetEntity from './TweetEntity.js';
 import TweetPublicMetrics from './TweetPublicMetrics.js';
 
 /**
@@ -69,7 +70,7 @@ class Tweet extends BaseStructure {
     /**
      * The entities parsed out of the tweet's text
      */
-    this.entities = null;
+    this.entities = data?.entities ? this._patchEntities(data.entities) : null;
 
     /**
      * Location tagged by the user in the tweet
@@ -124,6 +125,16 @@ class Tweet extends BaseStructure {
 
   _patchPublicMetrics(publicMetrics) {
     return new TweetPublicMetrics(publicMetrics);
+  }
+
+  /**
+   * Adds data to the entities property
+   * @param {Object} entities
+   * @private
+   * @returns {TweetEntity}
+   */
+  _patchEntities(entities) {
+    return new TweetEntity(entities);
   }
 }
 

--- a/src/structures/TweetEntity.js
+++ b/src/structures/TweetEntity.js
@@ -1,0 +1,54 @@
+'use strict';
+
+import BaseEntity from './BaseEntity.js';
+import Url from './Url.js';
+
+/**
+ * Holds entity present in a tweet
+ * @extends {BaseEntity}
+ */
+class TweetEntity extends BaseEntity {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    super(data);
+
+    /**
+     * The mentions present in the tweet
+     * @type {?Mention}
+     */
+
+    /**
+     * The hashtags present in the tweet
+     * @type {?Hastag}
+     */
+
+    /**
+     * The cashtags present in the tweet
+     * @type {?Cashtag}
+     */
+
+    /**
+     * The URLs present in the tweet
+     * @type {?Url}
+     */
+    this.urls = data?.urls ? this._patchUrls(data.urls) : null;
+  }
+
+  /**
+   * Adds data to the urls property
+   * @param {Array<Object>} urls An array of raw urls
+   * @private
+   * @returns {Array<Url>}
+   */
+  _patchUrls(urls) {
+    const urlsArray = [];
+    urls.forEach(url => {
+      urlsArray.push(new Url(url));
+    });
+    return urlsArray;
+  }
+}
+
+export default TweetEntity;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import BaseStructure from './BaseStructure.js';
-import Entity from './Entity.js';
+import UserEntity from './UserEntity.js';
 import UserPublicMetrics from './UserPublicMetrics.js';
 
 /**
@@ -126,10 +126,10 @@ class User extends BaseStructure {
    * Adds data to the entities property of the user
    * @param {Object} entities
    * @private
-   * @returns {Entity}
+   * @returns {UserEntity}
    */
   _patchEntities(entities) {
-    return new Entity(entities);
+    return new UserEntity(entities);
   }
 }
 

--- a/src/structures/UserEntity.js
+++ b/src/structures/UserEntity.js
@@ -1,0 +1,59 @@
+'use strict';
+
+import BaseEntity from './BaseEntity.js';
+import Url from './Url.js';
+
+/**
+ * Holds all entities present in a user's profile
+ * @extends {BaseEntity}
+ */
+class UserEntity extends BaseEntity {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    super(data.description);
+    /**
+     * The URL present in a user's bio
+     * @type {?Url}
+     */
+    this.urls = data?.url?.urls[0] ? new Url(data.url.urls[0]) : null;
+
+    /**
+     * The mentions present in the description of a user's bio
+     * @type {?Mention}
+     */
+
+    /**
+     * The hashtags present in the description of a user's bio
+     * @type {?Hastag}
+     */
+
+    /**
+     * The cashtags present in the description of a user's bio
+     * @type {?Cashtag}
+     */
+
+    /**
+     * The URLs present in the description of a user's bio
+     * @type {?Url}
+     */
+    this.descriptionUrls = data?.description?.urls ? this._patchDescriptionUrls(data.description.urls) : null;
+  }
+
+  /**
+   * Adds data to the descriptionUrls property
+   * @param {Array<Object>} descriptionUrls An array of raw descriptionUrls
+   * @private
+   * @returns {Array<Url>}
+   */
+  _patchDescriptionUrls(descriptionUrls) {
+    const descriptionUrlsArray = [];
+    descriptionUrls.forEach(descriptionUrl => {
+      descriptionUrlsArray.push(new Url(descriptionUrl));
+    });
+    return descriptionUrlsArray;
+  }
+}
+
+export default UserEntity;


### PR DESCRIPTION
This PR adds `BaseEntity`, a base class for all entity classes. It also adds two new classes `UserEntity` and `TweetEntity` that will hold the entities for `User` and `Tweet` respectively. The old `Entity` class will be removed soon.