### PR TITLE
fix: remove redundant code and fix some jsdoc tags

### DIFF
--- a/src/structures/BaseEntity.js
+++ b/src/structures/BaseEntity.js
@@ -7,7 +7,7 @@ import Cashtag from './Cashtag.js';
 /**
  * Base class for tweet and use entity classes
  */
-class Entity {
+class BaseEntity {
   /**
    * @param {Object} data
    */
@@ -74,4 +74,4 @@ class Entity {
   }
 }
 
-export default Entity;
+export default BaseEntity;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -35,7 +35,7 @@ class User extends BaseStructure {
 
     /**
      * Entities in the description of the user
-     * @type {?Entity}
+     * @type {?UserEntity}
      */
     this.entities = data?.entities ? this._patchEntities(data.entities) : null;
 

--- a/src/util/ResponseCleaner.js
+++ b/src/util/ResponseCleaner.js
@@ -28,9 +28,11 @@ export function cleanFetchManyTweetsResponse(response) {
     tweetDataCollection.set(data.id, tweetData);
   });
   response?.includes?.users.forEach(user => {
-    const tweetData = tweetDataCollection.get(user.pinned_tweet_id);
-    tweetData.includes.users.push(user);
-    tweetDataCollection.set(user.pinned_tweet_id, tweetData);
+    const tweetData = tweetDataCollection.find(tweetData => tweetData.data.author_id === user.id);
+    if (tweetData) {
+      tweetData.includes.users.push(user);
+      tweetDataCollection.set(tweetData.data.id, tweetData);
+    }
   });
   return tweetDataCollection;
 }

--- a/src/util/StructureBuilder.js
+++ b/src/util/StructureBuilder.js
@@ -3,8 +3,6 @@
 import User from '../structures/User.js';
 import Collection from './Collection.js';
 import Tweet from '../structures/Tweet.js';
-import UserPublicMetrics from '../structures/UserPublicMetrics.js';
-import Entity from '../structures/Entity.js';
 import Attachment from '../structures/Attachment.js';
 
 /**
@@ -52,10 +50,6 @@ function _patchTweet(client, element) {
   const tweet = new Tweet(client, element.data);
   const authorData = element?.includes?.users[0];
   if (authorData) tweet.author = new User(client, authorData);
-  const authorPublicMetricsData = authorData?.public_metrics;
-  if (authorPublicMetricsData) tweet.author.publicMetrics = new UserPublicMetrics(authorPublicMetricsData);
-  const authorEntityData = authorData?.entities;
-  if (authorEntityData) tweet.author.entities = new Entity(authorEntityData);
   const attachmentsData = element?.includes;
   if (attachmentsData) tweet.attachments = new Attachment(attachmentsData);
   return tweet;


### PR DESCRIPTION
This PR removes the redundant code that sets the data for `publicMetrics` and `entities` property of author `(User)` object in `StructureBuilder#_patchTweet` since those functionalities were moved into the `User` class itself in PR: #23. It also fixes the name of `BaseEntity` class and a jsdoc tag for the `User#entities`.