### PR TITLE
feat: add structure for keys of attachments in tweet

### DIFF
--- a/src/structures/AttachmentKey.js
+++ b/src/structures/AttachmentKey.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Holds keys for attachments in a tweet
+ */
+class AttachmentKey {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    /**
+     * An array of media keys for media present in the tweet
+     * @type {?Array<string>}
+     */
+    this.mediaKeys = data?.media_keys ? this._patchMediaKeys(data.media_keys) : null;
+
+    /**
+     * An array of IDs for polls present in the tweet
+     * @type {?Array<string}
+     */
+    this.pollIds = null;
+  }
+
+  /**
+   * Adds data to the mediaKeys
+   * @param {Array<string>} mediaKeys
+   * @private
+   * @returns {Array<string>}
+   */
+  _patchMediaKeys(mediaKeys) {
+    const mediaKeysArray = [];
+    mediaKeys.forEach(mediaKey => {
+      mediaKeysArray.push(mediaKey);
+    });
+    return mediaKeysArray;
+  }
+
+  /**
+   * Adds data to the pollIds
+   * @param {Array<string>} pollIds
+   * @private
+   * @returns {Array<string>}
+   */
+  _patchPollIds(pollIds) {
+    const pollIdsArray = [];
+    pollIds.forEach(pollId => {
+      pollIdsArray.push(pollId);
+    });
+    return pollIdsArray;
+  }
+}
+
+export default AttachmentKey;

--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import AttachmentKey from './AttachmentKey.js';
 import BaseStructure from './BaseStructure.js';
 import TweetEntity from './TweetEntity.js';
 import TweetPublicMetrics from './TweetPublicMetrics.js';
@@ -37,6 +38,11 @@ class Tweet extends BaseStructure {
      * The attachments in the tweet
      */
     this.attachments = null;
+
+    /**
+     * Keys of the attachments in the tweet
+     */
+    this.attachmentKeys = data?.attachments ? new AttachmentKey(data.attachments) : null;
 
     /**
      * The author of the tweet


### PR DESCRIPTION
This PR adds a new `AttachmentKey` structure that holds keys and ids of all attachments present in a tweet. The mentioned structure can be accessed through the new `attachmentKeys` property of `Tweet`.