### PR TITLE
feat: add structure for context annotations

### DIFF
--- a/src/structures/ContextAnnotation.js
+++ b/src/structures/ContextAnnotation.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Represents a context annotation parsed by Twitter from the tweet text
+ */
+class ContextAnnotation {
+  /**
+   * @param {Object} data
+   */
+  constructor(data) {
+    /**
+     * The id of the domain this annotation falls in
+     * @type {string}
+     */
+    this.domainID = data?.domain?.id ? data.domain.id : null;
+
+    /**
+     * The name of the domain this annotation falls in
+     * @type {string}
+     */
+    this.domainName = data?.domain?.name ? data.domain.name : null;
+
+    /**
+     * The description of the domain this annotation falls in
+     * @type {string}
+     */
+    this.domainDescription = data?.domain?.description ? data.domain.description : null;
+
+    /**
+     * The id of the entity this annotation is about
+     * @type {string}
+     */
+    this.entityID = data?.entity?.id ? data.entity.id : null;
+
+    /**
+     * The name of the entity this annotation is about
+     * @type {string}
+     */
+    this.entityName = data?.entity?.name ? data.entity.name : null;
+
+    /**
+     * The description of the entity this annotaion is about
+     * @type {string}
+     */
+    this.entityDescription = data?.entity?.description ? data.entity.description : null;
+  }
+}
+
+export default ContextAnnotation;

--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -2,6 +2,7 @@
 
 import AttachmentKey from './AttachmentKey.js';
 import BaseStructure from './BaseStructure.js';
+import ContextAnnotation from './ContextAnnotation.js';
 import TweetEntity from './TweetEntity.js';
 import TweetPublicMetrics from './TweetPublicMetrics.js';
 
@@ -58,8 +59,11 @@ class Tweet extends BaseStructure {
 
     /**
      * Context annotations for the tweet
+     * @type {ContextAnnotation}
      */
-    this.contextAnnotations = null;
+    this.contextAnnotations = data?.context_annotations
+      ? this._patchContextAnnotations(data.context_annotations)
+      : null;
 
     /**
      * Id of the original tweet of the conversation
@@ -141,6 +145,20 @@ class Tweet extends BaseStructure {
    */
   _patchEntities(entities) {
     return new TweetEntity(entities);
+  }
+
+  /**
+   * Adds data to the contextAnnotations
+   * @param {Array<Object>} contextAnnotations
+   * @private
+   * @returns {Array<ContextAnnotation>}
+   */
+  _patchContextAnnotations(contextAnnotations) {
+    const contextAnnotationsArray = [];
+    contextAnnotations.forEach(contextAnnotation => {
+      contextAnnotationsArray.push(new ContextAnnotation(contextAnnotation));
+    });
+    return contextAnnotationsArray;
   }
 }
 


### PR DESCRIPTION
This PR adds a new `ContextAnnotation` structure that represents a context annotation parsed by Twitter from the text of a tweet. The structure can be accessed through `Tweet#contextAnnotaions`.