### PR TITLE
feat(token): make token an object that holds bot credentials

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -16,15 +16,11 @@ class Client extends BaseClient {
     super();
 
     Object.defineProperty(this, 'token', { writable: true });
-    if (!this.token && 'TWITTER_TOKEN' in process.env) {
-      /**
-       * Bearer token for the bot. Defaults to `TWITTER_TOKEN` if it is present in the env variables, else sets it to null
-       * @type {?string}
-       */
-      this.token = process.env.TWITTER_TOKEN;
-    } else {
-      this.token = null;
-    }
+    /**
+     * The credentials of the bot
+     * @type {?Object}
+     */
+    this.token = null;
 
     /**
      * Time at which the client was marked as `READY`
@@ -53,14 +49,24 @@ class Client extends BaseClient {
   }
 
   /**
-   * Sets the Bearer Token as a property of the client for later use. Emits the `ready` event on success
-   * @param {string} [token=this.token] Bearer token of the bot
+   * An object containing bot credentials
+   * @typedef {object} token
+   * @property {string} consumerKey
+   * @property {string} consumerSecret
+   * @property {string} accessToken
+   * @property {string} accessTokenSecret
+   * @property {string} bearerToken
+   */
+
+  /**
+   * Sets the Token as a property of the client for later use. Emits the `ready` event on success
+   * @param {string} token Bearer token of the bot
    * @returns {string} The token that was provided
    * @example
    * client.login('Your-Bearer-Token');
    */
-  login(token = this.token) {
-    if (!token || typeof token !== 'string') {
+  login(token) {
+    if (!token) {
       throw new Error(Messages.TOKEN_INVALID);
     }
     this.token = token;

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -33,7 +33,7 @@ class RESTManager {
    */
   async fetchTweetById(id) {
     const endpoint = getTweetByIdEndpoint(id);
-    const header = getHeaderObject(HTTPverbs.GET, this.client.token);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = await res.json();
     return data;
@@ -46,7 +46,7 @@ class RESTManager {
    */
   async fetchTweetsByIds(ids) {
     const endpoint = getTweetsByIdsEndpoint(ids);
-    const header = getHeaderObject(HTTPverbs.GET, this.client.token);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = await res.json();
     return data;
@@ -59,7 +59,7 @@ class RESTManager {
    */
   async fetchUserById(id) {
     const endpoint = getUserByIdEndpoint(id);
-    const header = getHeaderObject(HTTPverbs.GET, this.client.token);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = await res.json();
     return data;
@@ -72,7 +72,7 @@ class RESTManager {
    */
   async fetchUserByUsername(username) {
     const endpoint = getUserByUsernameEndpoint(username);
-    const header = getHeaderObject(HTTPverbs.GET, this.client.token);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = await res.json();
     return data;
@@ -85,7 +85,7 @@ class RESTManager {
    */
   async fetchUsersByIds(ids) {
     const endpoint = getUsersByIdsEndpoint(ids);
-    const header = getHeaderObject(HTTPverbs.GET, this.client.token);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = await res.json();
     return data;
@@ -98,7 +98,7 @@ class RESTManager {
    */
   async fetchUsersByUsernames(usernames) {
     const endpoint = getUsersByUsernames(usernames);
-    const header = getHeaderObject(HTTPverbs.GET, this.client.token);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = res.json();
     return data;

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,12 @@
 import { Client } from '../src/index.js';
 
-const token = process.env.TWITTER_TOKEN;
+const token = {
+  consumerKey: process.env.CONSUMER_KEY,
+  consumerSecret: process.env.CONSUMER_SECRET,
+  accessToken: process.env.ACCESS_TOKEN,
+  accessTokenSecret: process.env.ACCESS_TOKEN_SECRET,
+  bearerToken: process.env.BEARER_TOKEN,
+};
 
 const client = new Client();
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -25,10 +25,10 @@ export class Client extends BaseClient {
   private rest: RESTManager;
   private _triggerClientReady(): void;
 
-  public token: string | null;
+  public token: token | null;
   public readyAt: Date | null;
   public users: UserManager;
-  public login(token?: string): string;
+  public login(token?: token): token;
 }
 
 export class Collection<K, V> extends BaseCollection<K, V> {
@@ -105,4 +105,12 @@ interface FetchUserOption {
 interface FetchUsersOption {
   user?: UserResolvable | Array<UserResolvable>;
   skipCacheCheck?: boolean;
+}
+
+interface token {
+  consumerKey: string,
+  consumerSecret: string,
+  accessToken: string,
+  accessTokenSecret: string,
+  bearerToken: string
 }


### PR DESCRIPTION
This PR makes the `token` property of `Client` an object. From now on the token will hold all the bot credentials and not just the bearer token. The bearer token will still be used where it can be used. Other credentials will be used only for the endpoints that support `OAuth 1.0 user context` only.