### PR TITLE
refactor: replace Snowflake with string type

### DIFF
--- a/src/managers/BaseManager.js
+++ b/src/managers/BaseManager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import Collection from '../util/Collection.js';
-import SnowflakeUtil from '../util/SnowflakeUtil.js';
 
 /**
  * Base class for all managers
@@ -52,11 +51,11 @@ class BaseManager {
   /**
    * Resolves a data entry to its respective Structure ID
    * @param {string|Object} structureResolvable The id or instance of the structure held by this Manager
-   * @returns {?Snowflake} An ID of the Structure held by this Manager
+   * @returns {?string} An ID of the Structure held by this Manager
    */
   resolveID(structureResolvable) {
     if (structureResolvable instanceof this.structureType) return structureResolvable.id;
-    if (SnowflakeUtil.isID(structureResolvable)) return structureResolvable;
+    if (typeof structureResolvable === 'string' && /^\d{1,}$/.test(structureResolvable)) return structureResolvable;
     return null;
   }
 }

--- a/src/managers/TweetManager.js
+++ b/src/managers/TweetManager.js
@@ -19,7 +19,7 @@ class TweetManager extends BaseManager {
 
     /**
      * The cache of this Manager
-     * @type {Collection<Snowflake, Tweet>}
+     * @type {Collection<string, Tweet>}
      * @name TweetManager#cache
      */
 
@@ -27,7 +27,7 @@ class TweetManager extends BaseManager {
      * Data tht resolves to a Tweet object. This can be:
      * * A Tweet object
      * * A tweet ID
-     * @typedef {Tweet|Snowflake} TweetResolvable
+     * @typedef {Tweet|string} TweetResolvable
      */
   }
 
@@ -40,7 +40,7 @@ class TweetManager extends BaseManager {
   /**
    * Resolves a TweetResolvable to a Tweet object
    * @param {TweetResolvable} tweetResolvable An id or instance of a Tweet object
-   * @returns {?Snowflake}
+   * @returns {?string}
    */
 
   /**
@@ -61,7 +61,7 @@ class TweetManager extends BaseManager {
   /**
    * Fetches tweet(s) from Twitter
    * @param {TweetResolvable|FetchTweetOptions|FetchTweetsOption} [options] Options to fetch tweet(s)
-   * @returns {Promise<Tweet>|Promise<Collection<Snowflake, Tweet>>}
+   * @returns {Promise<Tweet>|Promise<Collection<string, Tweet>>}
    * @example
    * // Fetch a single tweet using ID
    * client.tweets.fetch('12345567890')
@@ -102,7 +102,7 @@ class TweetManager extends BaseManager {
 
   /**
    * Fetches a single tweet from Twitter
-   * @param {Snowflake} query The ID of the tweet to fetch
+   * @param {string} query The ID of the tweet to fetch
    * @private
    */
   async _fetchSingle(query) {
@@ -111,7 +111,7 @@ class TweetManager extends BaseManager {
 
   /**
    * Fetches upto 100 tweets from twitter
-   * @param {Array<Snowflake>} query An array of IDs of tweets to fetch
+   * @param {Array<string>} query An array of IDs of tweets to fetch
    * @private
    */
   async _fetchMany(query) {

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -19,7 +19,7 @@ class UserManager extends BaseManager {
   }
   /**
    * The cache of this manager
-   * @type {Collection<Snowflake, User>}
+   * @type {Collection<string, User>}
    * @name UserManager#cache
    */
 
@@ -28,7 +28,7 @@ class UserManager extends BaseManager {
    * * A User object
    * * A user ID
    * * A username
-   * @typedef {User|Snowflake|string} UserResolvable
+   * @typedef {User|string} UserResolvable
    */
 
   /**
@@ -48,7 +48,7 @@ class UserManager extends BaseManager {
   /**
    * Resolves a UserResolvable to a user ID
    * @param {UserResolvable} userResolvable The id, username, or instance of a User object
-   * @returns {?Snowflake}
+   * @returns {?string}
    */
   resolveID(userResolvable) {
     const userID = super.resolveID(userResolvable);
@@ -75,7 +75,7 @@ class UserManager extends BaseManager {
   /**
    * Fetches user(s) from Twitter
    * @param {UserResolvable|FetchUserOptions|FetchUsersOptions} [options] Options to fetch user(s)
-   * @returns {Promise<User>|Promise<Collection<Snowflake, User>>}
+   * @returns {Promise<User>|Promise<Collection<string, User>>}
    * @example
    * // Fetch a user using ID
    * client.users.fetch('1234567890')
@@ -130,7 +130,7 @@ class UserManager extends BaseManager {
 
   /**
    * Fetches a single user from Twitter
-   * @param {Snowflake|string} query Either an ID or the username of the user to fetch
+   * @param {string} query Either an ID or the username of the user to fetch
    * @param {string} queryType Specifies whether the query is an id or username
    * @private
    */
@@ -141,7 +141,7 @@ class UserManager extends BaseManager {
 
   /**
    * Fetches users from Twitter
-   * @param {Array<Snowflake|string>} query An array of IDs or usernames of the users to fetch
+   * @param {Array<string|string>} query An array of IDs or usernames of the users to fetch
    * @param {string} queryType Specifies whether the query is an array of IDs or usernames
    * @private
    */

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -141,7 +141,7 @@ class UserManager extends BaseManager {
 
   /**
    * Fetches users from Twitter
-   * @param {Array<string|string>} query An array of IDs or usernames of the users to fetch
+   * @param {Array<string>} query An array of IDs or usernames of the users to fetch
    * @param {string} queryType Specifies whether the query is an array of IDs or usernames
    * @private
    */

--- a/src/rest/EndpointResolver.js
+++ b/src/rest/EndpointResolver.js
@@ -18,7 +18,7 @@ import {
 
 /**
  * Resolves the endpoint for fetching a tweet using its ID
- * @param {Snowflake} id The ID of the tweet
+ * @param {string} id The ID of the tweet
  * @returns {string} The endpoint url for fetching a single tweet using its ID
  */
 export function getTweetByIdEndpoint(id) {
@@ -28,7 +28,7 @@ export function getTweetByIdEndpoint(id) {
 
 /**
  * Resolves the endpoint for fetching upto 100 tweets using their IDs
- * @param {Array<Snowflake>} ids An array of IDs of the tweets to fetch
+ * @param {Array<string>} ids An array of IDs of the tweets to fetch
  * @returns {string} The endpoint url for fetching upto 100 tweets using their IDs
  */
 export function getTweetsByIdsEndpoint(ids) {
@@ -39,7 +39,7 @@ export function getTweetsByIdsEndpoint(ids) {
 
 /**
  * Resolves the endpoint for fetching a user using its ID
- * @param {Snowflake} id The ID of the user
+ * @param {string} id The ID of the user
  * @returns {string} The endpoint url for fetching a single user using its ID
  */
 export function getUserByIdEndpoint(id) {
@@ -59,7 +59,7 @@ export function getUserByUsernameEndpoint(username) {
 
 /**
  * Resolves the endpoint for fetching users using their IDs
- * @param {Array<Snowflake>} ids An array of IDs of the users to fetch
+ * @param {Array<string>} ids An array of IDs of the users to fetch
  * @returns {string} The endpoint url for fetching users using their IDs
  */
 export function getUsersByIdsEndpoint(ids) {

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -28,7 +28,7 @@ class RESTManager {
 
   /**
    * Fetches a tweet from Twitter using its ID
-   * @param {Snowflake} id ID of the tweet
+   * @param {string} id ID of the tweet
    * @returns {Promise<Object>} An object containing the tweet data
    */
   async fetchTweetById(id) {
@@ -41,7 +41,7 @@ class RESTManager {
 
   /**
    * Fetches upto 100 tweets from Twitter using their IDs
-   * @param {Array<Snowflake>} ids IDs of the tweets
+   * @param {Array<string>} ids IDs of the tweets
    * @returns {Promise<Object>} An object containing the tweets data
    */
   async fetchTweetsByIds(ids) {
@@ -54,7 +54,7 @@ class RESTManager {
 
   /**
    * Fetches a user from Twitter using its ID
-   * @param {Snowflake} id ID of the user
+   * @param {string} id ID of the user
    * @returns {Promise<Object>} An object containing the user data
    */
   async fetchUserById(id) {
@@ -80,7 +80,7 @@ class RESTManager {
 
   /**
    * Fetches users from Twitter using their IDs
-   * @param {Array<Snowflake>} ids An array of IDs of the users to fetch
+   * @param {Array<string>} ids An array of IDs of the users to fetch
    * @returns {Promise<Object>} An object containing the users data;
    */
   async fetchUsersByIds(ids) {

--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -25,7 +25,7 @@ class Tweet extends BaseStructure {
 
     /**
      * The id of the tweet
-     * @type {Snowflake}
+     * @type {string}
      */
     this.id = data.id;
 
@@ -53,7 +53,7 @@ class Tweet extends BaseStructure {
 
     /**
      * The id of the author of the tweet
-     * @type {Snowflake}
+     * @type {string}
      */
     this.authorID = data.author_id;
 
@@ -67,7 +67,7 @@ class Tweet extends BaseStructure {
 
     /**
      * Id of the original tweet of the conversation
-     * @type {?Snowflake}
+     * @type {?string}
      */
     this.conversationID = data.conversation_id ? data.conversation_id : null;
 
@@ -89,7 +89,7 @@ class Tweet extends BaseStructure {
 
     /**
      * Original tweet's author ID, if the tweet is a reply
-     * @type {?Snowflake}
+     * @type {?string}
      */
     this.replyTo = data.in_reply_to_user_id ? data.in_reply_to_user_id : null;
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -41,7 +41,7 @@ class User extends BaseStructure {
 
     /**
      * The ID of the user
-     * @type {Snowflake}
+     * @type {string}
      */
     this.id = data.id;
 
@@ -65,7 +65,7 @@ class User extends BaseStructure {
 
     /**
      * The pinned tweet ID of the user
-     * @type {?Snowflake}
+     * @type {?string}
      */
     this.pinnedTweetID = data.pinned_tweet_id ? data.pinned_tweet_id : null;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -37,27 +37,27 @@ export class Collection<K, V> extends BaseCollection<K, V> {
 export class RESTManager {
   constructor(client: Client);
   public client: Client;
-  public fetchTweetById(id: Snowflake): Promise<object>;
-  public fetchTweetsById(id: Array<Snowflake>): Promise<object>;
-  public fetchUserById(id: Snowflake): Promise<object>;
+  public fetchTweetById(id: string): Promise<object>;
+  public fetchTweetsById(id: Array<string>): Promise<object>;
+  public fetchUserById(id: string): Promise<object>;
   public fetchUserByUsername(username: string): Promise<object>;
-  public fetchUsersByIds(ids: Array<Snowflake>): Promise<object>;
+  public fetchUsersByIds(ids: Array<string>): Promise<object>;
   public fetchUsersByUsernames(usernames: Array<string>): Promise<object>;
 }
 
 export class Tweet extends BaseStructure {
   constructor(client: Client, data: object);
-  public id: Snowflake;
+  public id: string;
   public text: string;
   public attachments: object | null;
   public author: User | null;
-  public authorID: Snowflake;
+  public authorID: string;
   public contextAnnotations: object | null;
-  public conversationID: Snowflake | null;
+  public conversationID: string | null;
   public createdAt: Date;
   public entites: object | null;
   public geo: object | null;
-  public replyTo: Snowflake | null;
+  public replyTo: string | null;
   public language: string;
   public possiblySensitive: boolean | null;
   public publicMetrics: object | null;
@@ -72,11 +72,11 @@ export class User extends BaseStructure {
   public readonly createdAt: Date;
   public description: string | null;
   public entities: object | null;
-  public id: Snowflake;
+  public id: string;
   public location: string | null;
   public name: string;
   public pinnedTweet: Tweet | null;
-  public pinnedTweetID: Snowflake | null;
+  public pinnedTweetID: string | null;
   public profileImageURL: string;
   public protected: boolean;
   public publicMetrics: object | null;
@@ -86,15 +86,13 @@ export class User extends BaseStructure {
   public withheld: object | null;
 }
 
-export class UserManager extends BaseManager<Snowflake, User, UserResolvable> {
+export class UserManager extends BaseManager<string, User, UserResolvable> {
   constructor(client: Client);
   public fetch(options: UserResolvable | FetchUserOption | (FetchUsersOption & { user: UserResolvable })): Promise<User>;
-  public fetch(options?: FetchUsersOption): Promise<Collection<Snowflake, User>>;
+  public fetch(options?: FetchUsersOption): Promise<Collection<string, User>>;
 }
 
-type Snowflake = string;
-
-type UserResolvable = User | Snowflake | string;
+type UserResolvable = User | string;
 
 interface FetchUserOption {
   user: UserResolvable;


### PR DESCRIPTION
I started with `string` for the ID type but then I read about `Snowflake` and changed it. That was a mistake, so from now on all the IDs will have `string` type to keep it consistent with the API.