### PR TITLE
feat(Tweet): add hideReply and unhideReply methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter.js",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -809,6 +809,11 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "oauth-1.0a": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+      "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@discordjs/collection": "^0.1.6",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "oauth-1.0a": "^2.2.6"
   },
   "type": "module"
 }

--- a/src/rest/EndpointResolver.js
+++ b/src/rest/EndpointResolver.js
@@ -78,3 +78,13 @@ export function getUsersByUsernames(usernames) {
   const endpoint = `${usersByUsernames}?usernames=${usernamesArray}&user.fields=${userFields}&expansions=${expansionsForUser}&tweet.fields=${tweetFields}`;
   return endpoint;
 }
+
+/**
+ * Resolves the endpoint for hiding or unhiding a reply
+ * @param {string} id The ID of the reply tweet to hide or unhide
+ * @returns {string} The endpoint url to hide or unhide a reply
+ */
+export function getHideUnhideReplyEndpoint(id) {
+  const endpoint = `${tweetById}${id}/hidden`;
+  return endpoint;
+}

--- a/src/rest/HeaderResolver.js
+++ b/src/rest/HeaderResolver.js
@@ -1,17 +1,62 @@
 'use strict';
 
+import OAuth from 'oauth-1.0a';
+import crypto from 'crypto';
+
 /**
  * Generates a request header for HTTP calls
  * @param {string} HTTPverb The request method for this call
- * @param {string} token The Bearer Token for authorization
+ * @param {string} bearerToken The Bearer Token for authorization
  * @returns {object} A request header for HTTP calls
  */
-export function getHeaderObject(HTTPverb, token) {
+export function getHeaderObject(HTTPverb, bearerToken) {
   const headerObject = {
     method: HTTPverb,
     headers: {
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${bearerToken}`,
     },
   };
+  return headerObject;
+}
+
+/**
+ * Generates a request header for HTTP calls that requires user context (OAuth 1.0)
+ * @param {string} HTTPverb The request method for this call
+ * @param {object} token The bot credentials object
+ * @param {string} endpoint The endpoint url to hide-unhide a reply including the tweet ID
+ * @param {boolean} hideOrUnhide True if the reply is to be hidden else false
+ */
+export function getUserContextHeaderObject(HTTPverb, token, endpoint, hideOrUnhide) {
+  const oauth = new OAuth({
+    consumer: {
+      key: token.consumerKey,
+      secret: token.consumerSecret,
+    },
+    signature_method: 'HMAC-SHA1',
+    hash_function(base_string, key) {
+      return crypto.createHmac('sha1', key).update(base_string).digest('base64');
+    },
+  });
+
+  const userContextAuth = oauth.authorize(
+    {
+      url: endpoint.toString(),
+      method: HTTPverb,
+    },
+    {
+      key: token.accessToken,
+      secret: token.accessTokenSecret,
+    },
+  );
+
+  const headerObject = {
+    method: HTTPverb,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: oauth.toHeader(userContextAuth).Authorization,
+    },
+    body: JSON.stringify({ hidden: hideOrUnhide }),
+  };
+
   return headerObject;
 }

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -8,8 +8,9 @@ import {
   getUsersByIdsEndpoint,
   getUsersByUsernames,
   getTweetsByIdsEndpoint,
+  getHideUnhideReplyEndpoint,
 } from './EndpointResolver.js';
-import { getHeaderObject } from './HeaderResolver.js';
+import { getHeaderObject, getUserContextHeaderObject } from './HeaderResolver.js';
 import { HTTPverbs } from '../util/Constants.js';
 
 /**
@@ -101,6 +102,20 @@ class RESTManager {
     const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = res.json();
+    return data;
+  }
+
+  /**
+   * Hides or unhides a tweet that is a reply to one of the user's tweet
+   * @param {string} id The ID of the tweet to hide or unhide
+   * @param {boolean} hideOrUnhide True if the reply is to be hiddenn, else false
+   * @returns {Promise<object>}
+   */
+  async hideUnhideReply(id, hideOrUnhide) {
+    const endpoint = getHideUnhideReplyEndpoint(id);
+    const header = getUserContextHeaderObject(HTTPverbs.PUT, this.client.token, endpoint, hideOrUnhide);
+    const res = await fetch(endpoint, header);
+    const data = await res.json();
     return data;
   }
 }

--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -133,6 +133,26 @@ class Tweet extends BaseStructure {
     this.withheld = null;
   }
 
+  /**
+   * Hides a reply to the tweet
+   * @param {string} id The ID of the reply that is to be hidden
+   * @returns {Promise<boolean>} True if the reply is hidden otherwise false
+   */
+  async hideReply(id) {
+    const res = await this.client.rest.hideUnhideReply(id, true);
+    return res?.data?.hidden;
+  }
+
+  /**
+   * Unhides a reply to the tweet
+   * @param {string} id The ID of the reply that is to be unhidden
+   * @returns {Promise<boolean>} True if the reply is hidden otherwise false
+   */
+  async unhideReply(id) {
+    const res = await this.client.rest.hideUnhideReply(id, false);
+    return res?.data?.hidden;
+  }
+
   _patchPublicMetrics(publicMetrics) {
     return new TweetPublicMetrics(publicMetrics);
   }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -42,6 +42,7 @@ export const Events = {
 // HTTPverbs or Request Methods
 export const HTTPverbs = {
   GET: 'GET',
+  PUT: 'PUT',
 };
 
 // query


### PR DESCRIPTION
This PR adds two new methods to the `Tweet` structure. `Tweet#hideReply` hides a reply to the tweet and `Tweet#unhideReply` unhides a reply to the tweet. The PR also adds a new dependency for making user-context API calls like these two methods. I might make a module of my own for this later but till then we are going to use `oauth-1.0a` package.