### PR TITLE
fix: some changes for keeping consistency

### DIFF
--- a/src/rest/EndpointResolver.js
+++ b/src/rest/EndpointResolver.js
@@ -73,7 +73,7 @@ export function getUsersByIdsEndpoint(ids) {
  * @param {Array<string>} usernames An array of usernames of the users to fetch
  * @returns {string} The endpoint url for fetching users using their usernames
  */
-export function getUsersByUsernames(usernames) {
+export function getUsersByUsernamesEndpoint(usernames) {
   let usernamesArray = usernames.join();
   const endpoint = `${usersByUsernames}?usernames=${usernamesArray}&user.fields=${userFields}&expansions=${expansionsForUser}&tweet.fields=${tweetFields}`;
   return endpoint;

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -6,7 +6,7 @@ import {
   getUserByIdEndpoint,
   getUserByUsernameEndpoint,
   getUsersByIdsEndpoint,
-  getUsersByUsernames,
+  getUsersByUsernamesEndpoint,
   getTweetsByIdsEndpoint,
   getHideUnhideReplyEndpoint,
 } from './EndpointResolver.js';
@@ -98,7 +98,7 @@ class RESTManager {
    * @returns {Promise<Object>} An object containing the users data
    */
   async fetchUsersByUsernames(usernames) {
-    const endpoint = getUsersByUsernames(usernames);
+    const endpoint = getUsersByUsernamesEndpoint(usernames);
     const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = res.json();

--- a/src/structures/AttachmentKey.js
+++ b/src/structures/AttachmentKey.js
@@ -16,7 +16,7 @@ class AttachmentKey {
 
     /**
      * An array of IDs for polls present in the tweet
-     * @type {?Array<string}
+     * @type {?Array<string>}
      */
     this.pollIds = null;
   }

--- a/src/structures/Tweet.js
+++ b/src/structures/Tweet.js
@@ -91,7 +91,7 @@ class Tweet extends BaseStructure {
      * Original tweet's author ID, if the tweet is a reply
      * @type {?string}
      */
-    this.replyTo = data.in_reply_to_user_id ? data.in_reply_to_user_id : null;
+    this.inReplyToUserID = data.in_reply_to_user_id ? data.in_reply_to_user_id : null;
 
     /**
      * The language of the tweet
@@ -119,7 +119,7 @@ class Tweet extends BaseStructure {
      * Shows who can reply to the tweet
      * @type {string}
      */
-    this.canReply = data.reply_settings;
+    this.replySettings = data.reply_settings;
 
     /**
      * The platform used to post the tweet


### PR DESCRIPTION
This PR adds some new changes that are either to keep consistency with the API for property names of structures or for the internal naming convention of function names.