### PR TITLE
feat(User): add method for fetching user following

### DIFF
--- a/src/rest/EndpointResolver.js
+++ b/src/rest/EndpointResolver.js
@@ -88,3 +88,13 @@ export function getHideUnhideReplyEndpoint(id) {
   const endpoint = `${tweetById}${id}/hidden`;
   return endpoint;
 }
+
+/**
+ * Resolves the endpoint for user following
+ * @param {string} id The ID of the user whose following are to be fetched
+ * @returns {string} The endpoint url for fetching user following
+ */
+export function getUserFollowingEndpoint(id) {
+  const endpoint = `${userById}${id}/following?user.fields=${userFields}&expansions=${expansionsForUser}&tweet.fields=${tweetFields}`;
+  return endpoint;
+}

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -9,6 +9,7 @@ import {
   getUsersByUsernamesEndpoint,
   getTweetsByIdsEndpoint,
   getHideUnhideReplyEndpoint,
+  getUserFollowingEndpoint,
 } from './EndpointResolver.js';
 import { getHeaderObject, getUserContextHeaderObject } from './HeaderResolver.js';
 import { HTTPverbs } from '../util/Constants.js';
@@ -114,6 +115,19 @@ class RESTManager {
   async hideUnhideReply(id, hideOrUnhide) {
     const endpoint = getHideUnhideReplyEndpoint(id);
     const header = getUserContextHeaderObject(HTTPverbs.PUT, this.client.token, endpoint, hideOrUnhide);
+    const res = await fetch(endpoint, header);
+    const data = await res.json();
+    return data;
+  }
+
+  /**
+   * Fetches users followed by the user
+   * @param {string} id The ID of the user whose following are to be fetched
+   * @returns {Promise<object>}
+   */
+  async fetchUserFollowing(id) {
+    const endpoint = getUserFollowingEndpoint(id);
+    const header = getHeaderObject(HTTPverbs.GET, this.client.token.bearerToken);
     const res = await fetch(endpoint, header);
     const data = await res.json();
     return data;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { cleanFetchFollowingResponse } from '../util/ResponseCleaner.js';
+import { userBuilder } from '../util/StructureBuilder.js';
 import BaseStructure from './BaseStructure.js';
 import UserEntity from './UserEntity.js';
 import UserPublicMetrics from './UserPublicMetrics.js';
@@ -130,6 +132,17 @@ class User extends BaseStructure {
    */
   _patchEntities(entities) {
     return new UserEntity(entities);
+  }
+
+  /**
+   * Fetches following of the user
+   * @returns {Promise<Collection<string, User>>}
+   */
+  async fetchFollowing() {
+    const followingResponse = await this.client.rest.fetchUserFollowing(this.id);
+    const followingData = cleanFetchFollowingResponse(followingResponse);
+    const followingCollection = userBuilder(this.client, followingData);
+    return followingCollection;
   }
 }
 

--- a/src/util/ResponseCleaner.js
+++ b/src/util/ResponseCleaner.js
@@ -36,3 +36,18 @@ export function cleanFetchManyTweetsResponse(response) {
   });
   return tweetDataCollection;
 }
+
+export function cleanFetchFollowingResponse(response) {
+  const userDataCollection = new Collection();
+  response.data.forEach(data => {
+    const userData = { data: null, includes: { tweets: [] } };
+    userData.data = data;
+    userDataCollection.set(data.id, userData);
+  });
+  response?.includes?.tweets.forEach(tweet => {
+    const userData = userDataCollection.get(tweet.author_id);
+    userData.includes.tweets.push(tweet);
+    userDataCollection.set(tweet.author_id, userData);
+  });
+  return userDataCollection;
+}


### PR DESCRIPTION
This PR adds a new method to the `User` structure that fetches the users followed by the `User`. The underlying raw API caller `<RESTManager>#fetchUserFollowing` for this method is still incomplete. The `max_results` and `pagination` functionality is yet to be implemented on it.