### PR TITLE
feat: add paginated feature to follows-lookup endpoints

### DIFF
--- a/src/structures/Meta.js
+++ b/src/structures/Meta.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Holds meta information returned by paginated endpoints
+ */
+class Meta {
+  constructor(data) {
+    /**
+     * Number of results in the response
+     * @type {number}
+     */
+    this.resultCount = data.result_count ?? null;
+
+    /**
+     * Token to fetch the next page
+     * @type {string}
+     */
+    this.nextToken = data.next_token ?? null;
+
+    /**
+     * Token to fetch the previous page
+     * @type {number}
+     */
+    this.previousToken = data.previous_token ?? null;
+  }
+}
+
+export default Meta;

--- a/src/structures/PaginatedResponse.js
+++ b/src/structures/PaginatedResponse.js
@@ -1,0 +1,24 @@
+'use strict';
+
+import Meta from './Meta.js';
+
+/**
+ * Holds data for paginated response sent by the api
+ */
+class PaginatedResponse {
+  constructor(data, meta) {
+    /**
+     * Primary data in the response
+     * @type {?Collection}
+     */
+    this.data = data ?? null;
+
+    /**
+     * Meta information about the response
+     * @type {?Meta}
+     */
+    this.meta = meta ? new Meta(meta) : null;
+  }
+}
+
+export default PaginatedResponse;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,7 +1,11 @@
 'use strict';
 
+import { queryParameters } from '../util/Constants.js';
+import { cleanFetchFollowingResponse } from '../util/ResponseCleaner.js';
 import { userBuilder } from '../util/StructureBuilder.js';
+import APIOptions from './APIOptions.js';
 import BaseStructure from './BaseStructure.js';
+import PaginatedResponse from './PaginatedResponse.js';
 import UserEntity from './UserEntity.js';
 import UserPublicMetrics from './UserPublicMetrics.js';
 
@@ -134,23 +138,59 @@ class User extends BaseStructure {
   }
 
   /**
-   * Fetches following of the user
-   * @returns {Promise<Collection<string, User>>}
+   * Options used to fetch following of a user
+   * @typedef {Object} FetchFollowingOptions
+   * @property {number} [maxResults=100] Number of users to fetch per page
+   * @property {string} [nextPageToken=null] Token for fetching the next page
+   * @property {string} [previousPageToken=null] Token for fetching the previous page
    */
-  async fetchFollowing() {
-    const followingData = await this.client.rest.fetchUserFollowing(this.id);
-    const followingCollection = userBuilder(this.client, followingData);
-    return followingCollection;
+
+  /**
+   * Fetches following of the user
+   * @param {FetchFollowingOptions} options Options to fetch user following
+   * @returns {Promise<PaginatedResponse>}
+   */
+  async fetchFollowing(options) {
+    const queryParams = {
+      expansions: queryParameters.expansions.user,
+      max_results: options?.maxResults ?? 100,
+      pagination_token: options?.nextPageToken ?? options?.previousPageToken ?? null,
+      'tweet.fields': queryParameters.tweetFields,
+      'user.fields': queryParameters.userFields,
+    };
+    const apiOptions = new APIOptions(queryParams, null, false);
+    const response = await this.client.api.users(this.id).following.get(apiOptions);
+    const cleanedResponse = cleanFetchFollowingResponse(response);
+    const followingCollection = userBuilder(this.client, cleanedResponse);
+    return new PaginatedResponse(followingCollection, response.meta);
   }
 
   /**
-   * Fetches followers of the user
-   * @returns {Promise<Collection<string, User>>}
+   * Options used to fetch followers of a user
+   * @typedef {Object} FetchFollowersOptions
+   * @property {number} [maxResults=100] Number of users to fetch per page
+   * @property {string} [nextPageToken=null] Token for fetching the next page
+   * @property {string} [previousPageToken=null] Token for fetching the previous page
    */
-  async fetchFollowers() {
-    const followersData = await this.client.rest.fetchUserFollowers(this.id);
-    const followersCollection = userBuilder(this.client, followersData);
-    return followersCollection;
+
+  /**
+   * Fetches followers of the user
+   * @param {FetchFollowersOptions} options Options to fetch user followers
+   * @returns {Promise<PaginatedResponse>}
+   */
+  async fetchFollowers(options) {
+    const queryParams = {
+      expansions: queryParameters.expansions.user,
+      max_results: options?.maxResults ?? 100,
+      pagination_token: options?.nextPageToken ?? options?.previousPageToken ?? null,
+      'tweet.fields': queryParameters.tweetFields,
+      'user.fields': queryParameters.userFields,
+    };
+    const apiOptions = new APIOptions(queryParams, null, false);
+    const response = await this.client.api.users(this.id).followers.get(apiOptions);
+    const cleanedResponse = cleanFetchFollowingResponse(response);
+    const followersCollection = userBuilder(this.client, cleanedResponse);
+    return new PaginatedResponse(followersCollection, response.meta);
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,9 +11,11 @@ const token = {
 const client = new Client();
 
 client.on('ready', async () => {
-  const tweet = await client.tweets.fetch('1351284149588398081');
-  console.log(tweet);
-  tweet.unhideReply('1351284615734956032').then(b => console.log(b));
+  const user = await client.users.fetch('i_Shibi');
+  const data = await user.fetchFollowers({
+    maxResults: 1,
+  });
+  console.log(data);
 });
 
 client.login(token);


### PR DESCRIPTION
Made the `follows-lookup` endpoint calls to use the new rest module. The paginated feature is now exposed to the end-user, which means the lib won't make looping requests to the endpoints that send a paginated response. Only one request will be made and if the user wants to get more pages, they can use the `meta` information sent in the current response.