### PR TITLE
feat: add methods for blocking and unblocking a user

### DIFF
--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -6,7 +6,7 @@ import { queryParameters, queryTypes } from '../util/Constants.js';
 import { userBuilder } from '../util/StructureBuilder.js';
 import { cleanFetchManyUsersResponse } from '../util/ResponseCleaner.js';
 import APIOptions from '../structures/APIOptions.js';
-import { FollowRequest, UnfollowRequest } from '../structures/MiscResponses.js';
+import { FollowRequest, UnfollowRequest, BlockResponse, UnblockResponse } from '../structures/MiscResponses.js';
 
 /**
  * Manages the API methods for users and stores their cache
@@ -188,6 +188,31 @@ class UserManager extends BaseManager {
     const apiOptions = new APIOptions(null, null, true);
     const response = await this.client.api.users(this.client.user.id).following(id).delete(apiOptions);
     return new UnfollowRequest(response);
+  }
+
+  /**
+   * Blocks a user
+   * @param {string} id The ID of the user to block
+   * @returns {Promise<BlockResponse>}
+   */
+  async block(id) {
+    const body = {
+      target_user_id: id,
+    };
+    const apiOptions = new APIOptions(null, body, true);
+    const response = await this.client.api.users(this.client.user.id).blocking.post(apiOptions);
+    return new BlockResponse(response);
+  }
+
+  /**
+   * Unblocks a user
+   * @param {string} id The ID of the user to unblock
+   * @returns {Promise<UnblockResponse>}
+   */
+  async unblock(id) {
+    const apiOptions = new APIOptions(null, null, true);
+    const response = await this.client.api.users(this.client.user.id).blocking(id).delete(apiOptions);
+    return new UnblockResponse(response);
   }
 }
 

--- a/src/structures/MiscResponses.js
+++ b/src/structures/MiscResponses.js
@@ -44,3 +44,27 @@ export class UnfollowRequest {
     this.following = response?.data.following ?? null;
   }
 }
+
+/**
+ * Response sent when the user blocks someone
+ */
+export class BlockResponse {
+  constructor(response) {
+    /**
+     * Whether the user blocking someone
+     */
+    this.blocking = response?.data.blocking ?? null;
+  }
+}
+
+/**
+ * Response sent when the user unblocks someone
+ */
+export class UnblockResponse {
+  constructor(response) {
+    /**
+     * Whether the user blocking someone
+     */
+    this.blocking = response?.data.blocking ?? null;
+  }
+}

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -208,6 +208,22 @@ class User extends BaseStructure {
   async unfollow() {
     return this.client.users.unfollow(this.id);
   }
+
+  /**
+   * Blocks the user
+   * @returns {Promise<BlockResponse>}
+   */
+  async block() {
+    return this.client.users.block(this.id);
+  }
+
+  /**
+   * Unblocks the user
+   * @returns {Promise<UnblockResponse>}
+   */
+  async unblock() {
+    return this.client.users.unblock(this.id);
+  }
 }
 
 export default User;


### PR DESCRIPTION
This PR adds `block` and `unblock` methods on both `User` and `UserManager` classes in order to provide support for the latest released `Manage Blocks` endpoints.