### PR TITLE
feat: add support for manage lists endpoints and a list manager class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,6 @@
   },
   "typescript.suggest.autoImports": true,
   "typescript.referencesCodeLens.enabled": true,
-  "typescript.implementationsCodeLens.enabled": true
+  "typescript.implementationsCodeLens.enabled": true,
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jest": "^27.1.0",
         "lint-staged": "^11.1.2",
         "prettier": "^2.4.1",
-        "twitter-types": "^0.15.0",
+        "twitter-types": "^0.15.1",
         "typedoc": "^0.22.4",
         "typescript": "^4.4.3"
       },
@@ -9882,9 +9882,9 @@
       "dev": true
     },
     "node_modules/twitter-types": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.15.0.tgz",
-      "integrity": "sha512-tNUygdEdNSAb7mPNgpoi/iqk15Z+BgICkWShBHEwS4Jlszozb3cJQt93Mjk3tzsEVT1mewiwFdAZux1cq+h0Lw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.15.1.tgz",
+      "integrity": "sha512-FXFBmPqQT90hsu7XBGU2q6HZNlK0mCQfHstL/rhKukYVh5myRIwRXT7UxtSKF5fbrpiZPOqEsRBiE6N1rKyj6A==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -17655,9 +17655,9 @@
       }
     },
     "twitter-types": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.15.0.tgz",
-      "integrity": "sha512-tNUygdEdNSAb7mPNgpoi/iqk15Z+BgICkWShBHEwS4Jlszozb3cJQt93Mjk3tzsEVT1mewiwFdAZux1cq+h0Lw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.15.1.tgz",
+      "integrity": "sha512-FXFBmPqQT90hsu7XBGU2q6HZNlK0mCQfHstL/rhKukYVh5myRIwRXT7UxtSKF5fbrpiZPOqEsRBiE6N1rKyj6A==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jest": "^27.1.0",
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.1",
-    "twitter-types": "^0.15.0",
+    "twitter-types": "^0.15.1",
     "typedoc": "^0.22.4",
     "typescript": "^4.4.3"
   },

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -3,7 +3,7 @@ import { RESTManager } from '../rest/RESTManager';
 import { ClientEvents, StreamType } from '../util';
 import { CustomError, CustomTypeError } from '../errors';
 import { SampledTweetStream, FilteredTweetStream } from '../streams';
-import { UserManager, TweetManager, SpaceManager } from '../managers';
+import { UserManager, TweetManager, SpaceManager, ListManager } from '../managers';
 import { ClientCredentials, RequestData, ClientUser } from '../structures';
 import type { Response } from 'undici';
 import type { ClientCredentialsInterface, ClientOptions } from '../typings';
@@ -65,6 +65,11 @@ export class Client extends BaseClient {
   spaces: SpaceManager;
 
   /**
+   * The manager for {@link List} objects
+   */
+  lists: ListManager;
+
+  /**
    * The class for working with sampled tweet stream
    */
   sampledTweets: SampledTweetStream;
@@ -92,6 +97,7 @@ export class Client extends BaseClient {
     this.tweets = new TweetManager(this);
     this.users = new UserManager(this);
     this.spaces = new SpaceManager(this);
+    this.lists = new ListManager(this);
     this.sampledTweets = new SampledTweetStream(this);
     this.filteredTweets = new FilteredTweetStream(this);
   }

--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -16,6 +16,7 @@ const messages = {
   USER_CONTEXT_LOGIN_ERROR: (username: string) => `Could not fetch the user ${username}.`,
   CREDENTIALS_NOT_STRING: "One or more client credentials fields are missing or aren't of type string.",
   SPACE_RESOLVE_ID: (action: string) => `Could not resolve the space ID to ${action}.`,
+  LIST_RESOLVE_ID: (action: string) => `Could not resolve the list ID to ${action}.`,
 };
 
 for (const [key, message] of Object.entries(messages)) {

--- a/src/managers/ListManager.ts
+++ b/src/managers/ListManager.ts
@@ -1,0 +1,54 @@
+import { BaseManager } from './BaseManager';
+import { CustomError, CustomTypeError } from '../errors';
+import { List, RequestData } from '../structures';
+import type { Client } from '../client';
+import type { CreateListOptions, ListResolvable } from '../typings';
+import type {
+  DeleteListDeleteResponse,
+  PostListCreateJSONBody,
+  PostListCreateResponse,
+  Snowflake,
+} from 'twitter-types';
+
+/**
+ * The manager class that holds API methods for {@link List} objects and stores their cache
+ */
+export class ListManager extends BaseManager<Snowflake, ListResolvable, List> {
+  /**
+   * @param client The logged in {@link Client} instance
+   */
+  constructor(client: Client) {
+    super(client, List);
+  }
+
+  /**
+   * Creates a new list.
+   * @param options The options for creating a list
+   * @returns The created {@link List} object
+   */
+  async create(options: CreateListOptions): Promise<List> {
+    if (typeof options !== 'object') throw new CustomTypeError('INVALID_TYPE', 'options', 'object', true);
+    const body: PostListCreateJSONBody = {
+      name: options.name,
+      description: options.description,
+      private: options.private,
+    };
+    const requestData = new RequestData({ body, isUserContext: true });
+    const res: PostListCreateResponse = await this.client._api.lists.post(requestData);
+    const list = this.add(res.data.id, res.data);
+    return list;
+  }
+
+  /**
+   * Deletes a list.
+   * @param list The list to delete
+   * @returns A boolean representing whether the specified list has been deleted
+   */
+  async delete(list: ListResolvable): Promise<boolean> {
+    const listId = this.resolveId(list);
+    if (!listId) throw new CustomError('LIST_RESOLVE_ID', 'delete');
+    const requestData = new RequestData({ isUserContext: true });
+    const res: DeleteListDeleteResponse = await this.client._api.lists(listId).delete(requestData);
+    return res.data.deleted;
+  }
+}

--- a/src/managers/ListManager.ts
+++ b/src/managers/ListManager.ts
@@ -1,6 +1,6 @@
 import { BaseManager } from './BaseManager';
-import { CustomError, CustomTypeError } from '../errors';
 import { List, RequestData } from '../structures';
+import { CustomError, CustomTypeError } from '../errors';
 import type { Client } from '../client';
 import type { CreateListOptions, ListResolvable, UpdateListOptions, UserResolvable } from '../typings';
 import type {

--- a/src/managers/ListManager.ts
+++ b/src/managers/ListManager.ts
@@ -6,6 +6,8 @@ import type { CreateListOptions, ListResolvable, UpdateListOptions, UserResolvab
 import type {
   DeleteListDeleteResponse,
   DeleteListRemoveMemberResponse,
+  DeleteListUnfollowResponse,
+  DeleteListUnpinResponse,
   PostListAddMemberJSONBody,
   PostListAddMemberResponse,
   PostListCreateJSONBody,
@@ -14,8 +16,6 @@ import type {
   PostListFollowResponse,
   PostListPinJSONBody,
   PostListPinResponse,
-  PostListUnfollowResponse,
-  PostListUnpinResponse,
   PutListUpdateJSONBody,
   PutListUpdateResponse,
   Snowflake,
@@ -150,7 +150,7 @@ export class ListManager extends BaseManager<Snowflake, ListResolvable, List> {
     const loggedInUser = this.client.me;
     if (!loggedInUser) throw new CustomError('NO_LOGGED_IN_USER');
     const requestData = new RequestData({ isUserContext: true });
-    const res: PostListUnfollowResponse = await this.client._api
+    const res: DeleteListUnfollowResponse = await this.client._api
       .users(loggedInUser.id)
       .followed_lists(listId)
       .delete(requestData);
@@ -186,7 +186,7 @@ export class ListManager extends BaseManager<Snowflake, ListResolvable, List> {
     const loggedInUser = this.client.me;
     if (!loggedInUser) throw new CustomError('NO_LOGGED_IN_USER');
     const requestData = new RequestData({ isUserContext: true });
-    const res: PostListUnpinResponse = await this.client._api
+    const res: DeleteListUnpinResponse = await this.client._api
       .users(loggedInUser.id)
       .pinned_lists(listId)
       .delete(requestData);

--- a/src/managers/index.ts
+++ b/src/managers/index.ts
@@ -1,4 +1,5 @@
 export * from './BaseManager';
+export * from './ListManager';
 export * from './SpaceManager';
 export * from './TweetManager';
 export * from './UserManager';

--- a/src/structures/List.ts
+++ b/src/structures/List.ts
@@ -8,8 +8,24 @@ export class List extends BaseStructure {
    */
   name: string;
 
+  /**
+   * The description of the list
+   */
+  description: string | null;
+
+  /**
+   * Whether the list is private
+   */
+  private: boolean | null;
+
+  /**
+   * @param client The logged in {@link Client} instance
+   * @param data The raw data sent by the API for the list
+   */
   constructor(client: Client, data: APIList) {
     super(client, data);
     this.name = data.name;
+    this.description = data.description ?? null;
+    this.private = data.private ?? null;
   }
 }

--- a/src/structures/List.ts
+++ b/src/structures/List.ts
@@ -1,0 +1,15 @@
+import { BaseStructure } from './BaseStructure';
+import type { Client } from '../client';
+import type { APIList } from 'twitter-types';
+
+export class List extends BaseStructure {
+  /**
+   * The name of the list
+   */
+  name: string;
+
+  constructor(client: Client, data: APIList) {
+    super(client, data);
+    this.name = data.name;
+  }
+}

--- a/src/structures/index.ts
+++ b/src/structures/index.ts
@@ -2,6 +2,7 @@ export * from './misc';
 export * from './BaseStructure';
 export * from './ClientUser';
 export * from './FilteredTweetStreamRule';
+export * from './List';
 export * from './Media';
 export * from './Place';
 export * from './Poll';

--- a/src/typings/Interfaces.ts
+++ b/src/typings/Interfaces.ts
@@ -545,3 +545,23 @@ export interface CountTweetsOptions {
 export interface BaseStructureData {
   id: Snowflake;
 }
+
+/**
+ * The options used for creating a new list
+ */
+export interface CreateListOptions {
+  /**
+   * The name of the list
+   */
+  name: string;
+
+  /**
+   * The description of the list
+   */
+  description?: string;
+
+  /**
+   * Whether the list should be private
+   */
+  private?: boolean;
+}

--- a/src/typings/Interfaces.ts
+++ b/src/typings/Interfaces.ts
@@ -565,3 +565,8 @@ export interface CreateListOptions {
    */
   private?: boolean;
 }
+
+/**
+ * The options used to update a list
+ */
+export type UpdateListOptions = Partial<CreateListOptions>;

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -8,6 +8,7 @@ import type {
   SimplifiedUser,
   SimplifiedTweet,
   FilteredTweetStreamRule,
+  List,
 } from '../structures';
 import type {
   ClientEventsMapping,
@@ -54,6 +55,8 @@ export type TweetManagerFetchResult<T extends FetchTweetOptions | FetchTweetsOpt
 export type TweetResolvable = Tweet | SimplifiedTweet | Snowflake;
 
 export type SpaceResolvable = Space | SimplifiedSpace | Snowflake;
+
+export type ListResolvable = List | Snowflake;
 
 export type SpaceManagerFetchResult<T extends FetchSpaceOptions | FetchSpacesOptions> = T extends FetchSpaceOptions
   ? Space

--- a/src/util/Collection.ts
+++ b/src/util/Collection.ts
@@ -1,4 +1,4 @@
-import BaseCollection from '@discordjs/collection';
+import { Collection as BaseCollection } from '@discordjs/collection';
 
 /**
  * The data structure for storing objects mapped by their unique identifier property


### PR DESCRIPTION
Adds support for: https://developer.twitter.com/en/docs/twitter-api/lists/manage-lists/api-reference

TODO:

- [x] Add `ListManager` class
- [x] Add a `List` class
- [x] Add support for creating a new list `POST /2/lists`
- [x] Add support for deleting a list `DELETE /2/lists/:id`
- [x] Add support for updating a list `PUT /2/lists/:id`
- [x] Add support for adding a member to a list `POST /2/lists/members`
- [x] Add suppport for removing a member from a list `DELETE /2/lists/:id/members/:user_id`
- [x] Add support for following a list `POST /2/users/:id/followed_lists`
- [x] Add support for unfollowing a list `DELETE /2/users/:id/followed_lists/:list_id`
- [x] Add support for pinning a list `POST /2/users/:id/pinned_lists`
- [x] Add support for unpinning a list `DELETE /2/users/:id/pinned_lists/:list_id`