### PR TITLE
feat: emit matching rules collection in filteredTweetCreate event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jest": "^27.1.0",
         "lint-staged": "^11.1.2",
         "prettier": "^2.4.1",
-        "twitter-types": "^0.15.1",
+        "twitter-types": "^0.16.0",
         "typedoc": "^0.22.4",
         "typescript": "^4.4.3",
         "zx": "^4.2.0"
@@ -10014,9 +10014,9 @@
       "dev": true
     },
     "node_modules/twitter-types": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.15.1.tgz",
-      "integrity": "sha512-FXFBmPqQT90hsu7XBGU2q6HZNlK0mCQfHstL/rhKukYVh5myRIwRXT7UxtSKF5fbrpiZPOqEsRBiE6N1rKyj6A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.16.0.tgz",
+      "integrity": "sha512-dVqM+PPahrnP65KM3qvyHwwAnexhds4/FWVYb0cvKQAmW/JsTkqRQnLWwSdENZSaTWQC3HRX7a0LLDktSiqGpw==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -18047,9 +18047,9 @@
       }
     },
     "twitter-types": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.15.1.tgz",
-      "integrity": "sha512-FXFBmPqQT90hsu7XBGU2q6HZNlK0mCQfHstL/rhKukYVh5myRIwRXT7UxtSKF5fbrpiZPOqEsRBiE6N1rKyj6A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/twitter-types/-/twitter-types-0.16.0.tgz",
+      "integrity": "sha512-dVqM+PPahrnP65KM3qvyHwwAnexhds4/FWVYb0cvKQAmW/JsTkqRQnLWwSdENZSaTWQC3HRX7a0LLDktSiqGpw==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jest": "^27.1.0",
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.1",
-    "twitter-types": "^0.15.1",
+    "twitter-types": "^0.16.0",
     "typedoc": "^0.22.4",
     "typescript": "^4.4.3",
     "zx": "^4.2.0"

--- a/src/structures/FilteredTweetStreamRule.ts
+++ b/src/structures/FilteredTweetStreamRule.ts
@@ -1,6 +1,6 @@
 import { BaseStructure } from './BaseStructure';
 import type { Client } from '../client';
-import type { APIFilteredTweetStreamRule } from 'twitter-types';
+import type { APIFilteredTweetStreamRule, Snowflake } from 'twitter-types';
 
 export class FilteredTweetStreamRule extends BaseStructure {
   tag: string | null;
@@ -14,5 +14,25 @@ export class FilteredTweetStreamRule extends BaseStructure {
     super(client, data);
     this.tag = data.tag ?? null;
     this.value = data.value;
+  }
+}
+
+/**
+ * The rule that matched against the filtered tweet
+ */
+export class MatchingRule {
+  /**
+   * The id of the filter rule
+   */
+  id: Snowflake;
+
+  /**
+   * The tag of the filter rule
+   */
+  tag: string | null;
+
+  constructor(data: { id: Snowflake; tag?: string }) {
+    this.id = data.id;
+    this.tag = typeof data.tag === 'string' ? (data.tag.length > 0 ? data.tag : null) : null;
   }
 }

--- a/src/typings/Interfaces.ts
+++ b/src/typings/Interfaces.ts
@@ -1,6 +1,6 @@
 import type { Client } from '../client';
-import type { ClientEvents } from '../util';
-import type { Tweet, RequestData } from '../structures';
+import type { ClientEvents, Collection } from '../util';
+import type { Tweet, RequestData, MatchingRule } from '../structures';
 import type { TweetResolvable, UserResolvable, SpaceResolvable } from './Types';
 import type {
   Granularity,
@@ -57,7 +57,7 @@ export interface ClientCredentialsInterface {
 }
 
 export interface ClientEventsMapping {
-  filteredTweetCreate: [tweet: Tweet];
+  filteredTweetCreate: [tweet: Tweet, matchingRules: Collection<Snowflake, MatchingRule>];
   keepAliveSignal: [stream: 'sampled' | 'filtered'];
   partialError: [partialError: Record<string, unknown>];
   ready: [client: Client];


### PR DESCRIPTION
Adds a collection of matched rules as a second parameter to the `filteredTweetCreate` event. This will help in deciding which rule(s) got matched against the given filtered tweet.